### PR TITLE
feat: update web-vitals to v5.0.1 and replace FID with INP metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "superstruct": "^2.0.2",
-    "web-vitals": "^4.2.4",
+    "web-vitals": "^5.0.1",
     "zod": "4.0.0-beta.20250505T195954"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       web-vitals:
-        specifier: ^4.2.4
-        version: 4.2.4
+        specifier: ^5.0.1
+        version: 5.0.1
       zod:
         specifier: 4.0.0-beta.20250505T195954
         version: 4.0.0-beta.20250505T195954
@@ -5804,8 +5804,8 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  web-vitals@4.2.4:
-    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+  web-vitals@5.0.1:
+    resolution: {integrity: sha512-BsULPWaCKAAtNntUz0aJq1cu1wyuWmDzf4N6vYNMbYA6zzQAf2pzCYbyClf+Ui2MI54bt225AwugXIfL1W+Syg==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -12172,7 +12172,7 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  web-vitals@4.2.4: {}
+  web-vitals@5.0.1: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,10 @@ import { createRoot } from 'react-dom/client'
 import GA4 from 'react-ga4'
 import type {
   CLSMetricWithAttribution,
-  FIDMetricWithAttribution,
+  INPMetricWithAttribution,
   LCPMetricWithAttribution,
 } from 'web-vitals/attribution'
-import { onCLS, onFID, onLCP } from 'web-vitals/attribution'
+import { onCLS, onINP, onLCP } from 'web-vitals/attribution'
 
 import App from './App'
 import type { EventParams } from './vite-env'
@@ -35,7 +35,7 @@ if (process.env.NODE_ENV === 'production') {
     value,
   }:
     | CLSMetricWithAttribution
-    | FIDMetricWithAttribution
+    | INPMetricWithAttribution
     | LCPMetricWithAttribution) {
     const eventParams: EventParams = {
       // Optional.
@@ -56,11 +56,11 @@ if (process.env.NODE_ENV === 'production') {
       case 'CLS':
         eventParams.debug_target = attribution.largestShiftTarget
         break
-      case 'FID':
-        eventParams.debug_target = attribution.eventTarget
+      case 'INP':
+        eventParams.debug_target = attribution.interactionTarget
         break
       case 'LCP':
-        eventParams.debug_target = attribution.element
+        eventParams.debug_target = attribution.elementRenderDelay
         break
     }
 
@@ -70,7 +70,7 @@ if (process.env.NODE_ENV === 'production') {
   }
 
   onCLS(sendToGoogleAnalytics)
-  onFID(sendToGoogleAnalytics)
+  onINP(sendToGoogleAnalytics)
   onLCP(sendToGoogleAnalytics)
 }
 


### PR DESCRIPTION
- Updated the web-vitals package from version 4.2.4 to 5.0.1 in package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated performance tracking to use the Interaction to Next Paint (INP) metric instead of First Input Delay (FID).
  - Enhanced attribution details for Largest Contentful Paint (LCP) metrics.

- **Chores**
  - Upgraded the web-vitals dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->